### PR TITLE
Add BufferLines and SetBufferLines, Deprecated some API

### DIFF
--- a/vim/api.go
+++ b/vim/api.go
@@ -123,6 +123,11 @@ func (p *Pipeline) BufferLineCount(buffer Buffer, result *int) {
 }
 
 // BufferLine returns the line at the given index.
+// Deprecated: use BufferLines instead.
+//     for positive indices (including 0) use
+//         "BufferLines(buffer, index, index+1, true)"
+//     for negative indices use
+//         "BufferLines(buffer, index-1, index, true)"
 func (v *Vim) BufferLine(buffer Buffer, index int) ([]byte, error) {
 	var result []byte
 	err := v.call("buffer_get_line", &result, buffer, index)
@@ -130,31 +135,60 @@ func (v *Vim) BufferLine(buffer Buffer, index int) ([]byte, error) {
 }
 
 // BufferLine returns the line at the given index.
+// Deprecated: use BufferLines instead.
+//     for positive indices (including 0) use
+//         "BufferLines(buffer, index, index+1, true)"
+//     for negative indices use
+//         "BufferLines(buffer, index-1, index, true)"
 func (p *Pipeline) BufferLine(buffer Buffer, index int, result *[]byte) {
 	p.call("buffer_get_line", result, buffer, index)
 }
 
 // SetBufferLine sets the line at the given index.
+// Deprecated: use SetBufferLines instead.
+//     for positive indices use
+//         "SetBufferLines(buffer, index, index+1, true, [lines])"
+//     for negative indices use
+//         "SetBufferLines(buffer, index-1, index, true, [lines])"
 func (v *Vim) SetBufferLine(buffer Buffer, index int, line []byte) error {
 	return v.call("buffer_set_line", nil, buffer, index, line)
 }
 
 // SetBufferLine sets the line at the given index.
+// Deprecated: use SetBufferLines instead.
+//     for positive indices use
+//         "SetBufferLines(buffer, index, index+1, true, [lines])"
+//     for negative indices use
+//         "SetBufferLines(buffer, index-1, index, true, [lines])"
 func (p *Pipeline) SetBufferLine(buffer Buffer, index int, line []byte) {
 	p.call("buffer_set_line", nil, buffer, index, line)
 }
 
 // DeleteBufferLine deletes the line at the given index.
+// Deprecated: use SetBufferLines instead.
+//     for positive indices use
+//         "SetBufferLines(buffer, index, index+1, true, [])"
+//     for negative indices use
+//         "SetBufferLines(buffer, index-1, index, true, [])"
 func (v *Vim) DeleteBufferLine(buffer Buffer, index int) error {
 	return v.call("buffer_del_line", nil, buffer, index)
 }
 
 // DeleteBufferLine deletes the line at the given index.
+// Deprecated: use SetBufferLines instead.
+//     for positive indices use
+//         "SetBufferLines(buffer, index, index+1, true, [])"
+//     for negative indices use
+//         "SetBufferLines(buffer, index-1, index, true, [])"
 func (p *Pipeline) DeleteBufferLine(buffer Buffer, index int) {
 	p.call("buffer_del_line", nil, buffer, index)
 }
 
 // BufferLineSlice retrieves a line range from a buffer.
+// Deprecated: use BufferLines(buffer, newstart, newend, strictIndexing)
+//     newstart = start + int(not includeStart) - int(start < 0)
+//     newend = end + int(includeEnd) - int(end < 0)
+//     int(bool) = 1 if bool is true else 0
 func (v *Vim) BufferLineSlice(buffer Buffer, start int, end int, includeStart bool, includeEnd bool) ([][]byte, error) {
 	var result [][]byte
 	err := v.call("buffer_get_line_slice", &result, buffer, start, end, includeStart, includeEnd)
@@ -162,18 +196,82 @@ func (v *Vim) BufferLineSlice(buffer Buffer, start int, end int, includeStart bo
 }
 
 // BufferLineSlice retrieves a line range from a buffer.
+// Deprecated: use BufferLines(buffer, newstart, newend, strictIndexing)
+//     newstart = start + int(not includeStart) - int(start < 0)
+//     newend = end + int(includeEnd) - int(end < 0)
+//     int(bool) = 1 if bool is true else 0
 func (p *Pipeline) BufferLineSlice(buffer Buffer, start int, end int, includeStart bool, includeEnd bool, result *[][]byte) {
 	p.call("buffer_get_line_slice", result, buffer, start, end, includeStart, includeEnd)
 }
 
 // SetBufferLineSlice replaces a line range on a buffer.
+// Deprecated: use SetBufferLines(buffer, newstart, newend, false, lines)
+//     newstart = start + int(not includeStart) + int(start < 0)
+//     newend = end + int(includeEnd) + int(end < 0)
+//     int(bool) = 1 if bool is true else 0
 func (v *Vim) SetBufferLineSlice(buffer Buffer, start int, end int, includeStart bool, includeEnd bool, replacement [][]byte) error {
 	return v.call("buffer_set_line_slice", nil, buffer, start, end, includeStart, includeEnd, replacement)
 }
 
 // SetBufferLineSlice replaces a line range on a buffer.
+// Deprecated: use SetBufferLines(buffer, newstart, newend, false, lines)
+//     newstart = start + int(not includeStart) + int(start < 0)
+//     newend = end + int(includeEnd) + int(end < 0)
+//     int(bool) = 1 if bool is true else 0
 func (p *Pipeline) SetBufferLineSlice(buffer Buffer, start int, end int, includeStart bool, includeEnd bool, replacement [][]byte) {
 	p.call("buffer_set_line_slice", nil, buffer, start, end, includeStart, includeEnd, replacement)
+}
+
+// BufferLines retrieves a line range from a buffer.
+// Indexing is zero-based, end-exclusive. Negative indices are interpreted
+// as length+1+index, i e -1 refers to the index past the end. So to get the
+// last element set start=-2 and end=-1.
+//
+// Out-of-bounds indices are clamped to the nearest valid value, unless
+// strict_indexing is set.
+func (v *Vim) BufferLines(buffer Buffer, start int, end int, strictIndexing bool) ([][]byte, error) {
+	var result [][]byte
+	err := v.call("buffer_get_lines", &result, buffer, start, end, strictIndexing)
+	return result, err
+}
+
+// BufferLines retrieves a line range from a buffer.
+// Indexing is zero-based, end-exclusive. Negative indices are interpreted
+// as length+1+index, i e -1 refers to the index past the end. So to get the
+// last element set start=-2 and end=-1.
+//
+// Out-of-bounds indices are clamped to the nearest valid value, unless
+// strict_indexing is set.
+func (p *Pipeline) BufferLines(buffer Buffer, start int, end int, strictIndexing bool, result *[][]byte) {
+	p.call("buffer_get_lines", result, buffer, start, end, strictIndexing)
+}
+
+// SetBufferLines replaces a line range on a buffer.
+// Indexing is zero-based, end-exclusive. Negative indices are interpreted
+// as length+1+index, i e -1 refers to the index past the end. So to change
+// or delete the last element set start=-2 and end=-1.
+//
+// To insert lines at a given index, set both start and end to the same index.
+// To delete a range of lines, set replacement to an empty array.
+//
+// Out-of-bounds indices are clamped to the nearest valid value, unless
+// strict_indexing is set.
+func (v *Vim) SetBufferLines(buffer Buffer, start int, end int, strictIndexing bool, replacement [][]byte) error {
+	return v.call("buffer_set_lines", nil, buffer, start, end, strictIndexing, replacement)
+}
+
+// SetBufferLines replaces a line range on a buffer.
+// Indexing is zero-based, end-exclusive. Negative indices are interpreted
+// as length+1+index, i e -1 refers to the index past the end. So to change
+// or delete the last element set start=-2 and end=-1.
+//
+// To insert lines at a given index, set both start and end to the same index.
+// To delete a range of lines, set replacement to an empty array.
+//
+// Out-of-bounds indices are clamped to the nearest valid value, unless
+// strict_indexing is set.
+func (p *Pipeline) SetBufferLines(buffer Buffer, start int, end int, strictIndexing bool, replacement [][]byte) {
+	p.call("buffer_set_lines", nil, buffer, start, end, strictIndexing, replacement)
 }
 
 // BufferVar gets a buffer-scoped (b:) variable.
@@ -269,11 +367,13 @@ func (p *Pipeline) IsBufferValid(buffer Buffer, result *bool) {
 }
 
 // InsertBUffer inserts a range of lines to a buffer at the specified index.
+// Deprecated: use SetBufferLines(buffer, lnum, lnum, true, lines)
 func (v *Vim) InsertBuffer(buffer Buffer, lnum int, lines [][]byte) error {
 	return v.call("buffer_insert", nil, buffer, lnum, lines)
 }
 
 // InsertBUffer inserts a range of lines to a buffer at the specified index.
+// Deprecated: use SetBufferLines(buffer, lnum, lnum, true, lines)
 func (p *Pipeline) InsertBuffer(buffer Buffer, lnum int, lines [][]byte) {
 	p.call("buffer_insert", nil, buffer, lnum, lines)
 }

--- a/vim/api.json
+++ b/vim/api.json
@@ -103,6 +103,30 @@
         {
             "async": false,
             "can_fail": true,
+            "name": "buffer_get_lines",
+            "parameters": [
+                [
+                    "Buffer",
+                    "buffer"
+                ],
+                [
+                    "Integer",
+                    "start"
+                ],
+                [
+                    "Integer",
+                    "end"
+                ],
+                [
+                    "Boolean",
+                    "strict_indexing"
+                ]
+            ],
+            "return_type": "ArrayOf(String)"
+        },
+        {
+            "async": false,
+            "can_fail": true,
             "name": "buffer_set_line_slice",
             "parameters": [
                 [
@@ -124,6 +148,34 @@
                 [
                     "Boolean",
                     "include_end"
+                ],
+                [
+                    "ArrayOf(String)",
+                    "replacement"
+                ]
+            ],
+            "return_type": "void"
+        },
+        {
+            "async": false,
+            "can_fail": true,
+            "name": "buffer_set_lines",
+            "parameters": [
+                [
+                    "Buffer",
+                    "buffer"
+                ],
+                [
+                    "Integer",
+                    "start"
+                ],
+                [
+                    "Integer",
+                    "end"
+                ],
+                [
+                    "Boolean",
+                    "strict_indexing"
                 ],
                 [
                     "ArrayOf(String)",

--- a/vim/genapi.go
+++ b/vim/genapi.go
@@ -55,32 +55,98 @@ var methods = []*struct {
 		Sm:     "buffer_get_line",
 		Return: "[]byte",
 		Params: []param{{"buffer", "Buffer"}, {"index", "int"}},
-		Doc:    `// BufferLine returns the line at the given index.`,
+		Doc: `
+// BufferLine returns the line at the given index.
+// Deprecated: use BufferLines instead.
+//     for positive indices (including 0) use
+//         "BufferLines(buffer, index, index+1, true)"
+//     for negative indices use
+//         "BufferLines(buffer, index-1, index, true)"
+`,
 	},
 	{
 		Name:   "SetBufferLine",
 		Sm:     "buffer_set_line",
 		Params: []param{{"buffer", "Buffer"}, {"index", "int"}, {"line", "[]byte"}},
-		Doc:    `// SetBufferLine sets the line at the given index.`,
+		Doc: `
+// SetBufferLine sets the line at the given index.
+// Deprecated: use SetBufferLines instead.
+//     for positive indices use
+//         "SetBufferLines(buffer, index, index+1, true, [lines])"
+//     for negative indices use
+//         "SetBufferLines(buffer, index-1, index, true, [lines])"
+`,
 	},
 	{
 		Name:   "DeleteBufferLine",
 		Sm:     "buffer_del_line",
 		Params: []param{{"buffer", "Buffer"}, {"index", "int"}},
-		Doc:    `// DeleteBufferLine deletes the line at the given index.`,
+		Doc: `
+// DeleteBufferLine deletes the line at the given index.
+// Deprecated: use SetBufferLines instead.
+//     for positive indices use
+//         "SetBufferLines(buffer, index, index+1, true, [])"
+//     for negative indices use
+//         "SetBufferLines(buffer, index-1, index, true, [])"
+
+`,
 	},
 	{
 		Name:   "BufferLineSlice",
 		Sm:     "buffer_get_line_slice",
 		Return: "[][]byte",
 		Params: []param{{"buffer", "Buffer"}, {"start", "int"}, {"end", "int"}, {"includeStart", "bool"}, {"includeEnd", "bool"}},
-		Doc:    `// BufferLineSlice retrieves a line range from a buffer.`,
+		Doc: `
+// BufferLineSlice retrieves a line range from a buffer.
+// Deprecated: use BufferLines(buffer, newstart, newend, strictIndexing)
+//     newstart = start + int(not includeStart) - int(start < 0)
+//     newend = end + int(includeEnd) - int(end < 0)
+//     int(bool) = 1 if bool is true else 0
+`,
 	},
 	{
 		Name:   "SetBufferLineSlice",
 		Sm:     "buffer_set_line_slice",
 		Params: []param{{"buffer", "Buffer"}, {"start", "int"}, {"end", "int"}, {"includeStart", "bool"}, {"includeEnd", "bool"}, {"replacement", "[][]byte"}},
-		Doc:    `// SetBufferLineSlice replaces a line range on a buffer.`,
+		Doc: `
+// SetBufferLineSlice replaces a line range on a buffer.
+// Deprecated: use SetBufferLines(buffer, newstart, newend, false, lines)
+//     newstart = start + int(not includeStart) + int(start < 0)
+//     newend = end + int(includeEnd) + int(end < 0)
+//     int(bool) = 1 if bool is true else 0
+`,
+	},
+	{
+		Name:   "BufferLines",
+		Sm:     "buffer_get_lines",
+		Return: "[][]byte",
+		Params: []param{{"buffer", "Buffer"}, {"start", "int"}, {"end", "int"}, {"strictIndexing", "bool"}},
+		Doc: `
+// BufferLines retrieves a line range from a buffer.
+// Indexing is zero-based, end-exclusive. Negative indices are interpreted
+// as length+1+index, i e -1 refers to the index past the end. So to get the
+// last element set start=-2 and end=-1.
+//
+// Out-of-bounds indices are clamped to the nearest valid value, unless
+// strict_indexing is set.
+`,
+	},
+	{
+		Name:   "SetBufferLines",
+		Sm:     "buffer_set_lines",
+		Params: []param{{"buffer", "Buffer"}, {"start", "int"}, {"end", "int"}, {"strictIndexing", "bool"}, {"replacement", "[][]byte"}},
+		Doc: `
+// SetBufferLines replaces a line range on a buffer.
+// Indexing is zero-based, end-exclusive. Negative indices are interpreted
+// as length+1+index, i e -1 refers to the index past the end. So to change
+// or delete the last element set start=-2 and end=-1.
+//
+// To insert lines at a given index, set both start and end to the same index.
+// To delete a range of lines, set replacement to an empty array.
+//
+// Out-of-bounds indices are clamped to the nearest valid value, unless
+// strict_indexing is set.
+`,
 	},
 	{
 		Name:   "BufferVar",
@@ -149,7 +215,10 @@ var methods = []*struct {
 		Name:   "InsertBuffer",
 		Sm:     "buffer_insert",
 		Params: []param{{"buffer", "Buffer"}, {"lnum", "int"}, {"lines", "[][]byte"}},
-		Doc:    `// InsertBUffer inserts a range of lines to a buffer at the specified index.`,
+		Doc: `
+// InsertBUffer inserts a range of lines to a buffer at the specified index.
+// Deprecated: use SetBufferLines(buffer, lnum, lnum, true, lines)
+`,
 	},
 	{
 		Name:   "BufferMark",


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/pull/4083

Add
```go
BufferLines(buffer Buffer, start int, end int, strictIndexing bool) ([][]byte, error)
SetBufferLines(buffer Buffer, start int, end int, strictIndexing bool, replacement [][]byte) error
```

Deprecated
```go
BufferLine(buffer Buffer, index int) ([]byte, error)
SetBufferLine(buffer Buffer, index int, line []byte) error
DeleteBufferLine(buffer Buffer, index int) error
BufferLineSlice(buffer Buffer, start int, end int, includeStart bool, includeEnd bool) ([][]byte, error)
SetBufferLineSlice(buffer Buffer, start int, end int, includeStart bool, includeEnd bool, replacement [][]byte) error
InsertBuffer(buffer Buffer, lnum int, lines [][]byte) error
```

===

Hi.
Thanks for Neovim Go interface!
It's very fast, simple and easy to use. amazing!
And did you using deoplete-go? (I found you in stargazers) also thanks.

BTW, Neovim buffer API has been changed.
Add `buffer_get_lines`, `buffer_set_lines`, deprecated some API.
I have updated it. and add API description from [buffer.c](https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c)
but, I'm Golang newbie.
If exists the wrong point or need to fix the `Doc` comments, Please point out.
I will revise it.

Also, Neovim have new `buffer_add_highlight` & `buffer_clear_highlight` API.
I'm split the pull request. will create.

===
Off topic:
I have a question for you.
If you don't mind, Can I send e-mail?

Thanks.